### PR TITLE
Fix error calculating average time spent on course/topic 

### DIFF
--- a/src/Http/Requests/Admin/CourseStatsRequest.php
+++ b/src/Http/Requests/Admin/CourseStatsRequest.php
@@ -10,7 +10,7 @@ class CourseStatsRequest extends FormRequest
 {
     public function authorize()
     {
-        return $this->user()->can('viewAny', Report::class) || $this->user()->can('update', Course::class);
+        return $this->user()->can('viewAny', Report::class) || $this->user()->can('update', $this->getCourse());
     }
 
     protected function prepareForValidation()

--- a/src/Stats/Course/AverageTime.php
+++ b/src/Stats/Course/AverageTime.php
@@ -26,6 +26,6 @@ class AverageTime extends AbstractCourseStat
             ->groupBy($courseTable . '.id', $courseProgressTable . '.user_id')
             ->get();
 
-        return $results->average('time');
+        return $results->average('time') ?? 0;
     }
 }

--- a/src/Stats/Topic/AverageTime.php
+++ b/src/Stats/Topic/AverageTime.php
@@ -6,6 +6,6 @@ class AverageTime extends AbstractTopicStat
 {
     public function calculate(): int
     {
-        return $this->topic->progress()->average('seconds');
+        return $this->topic->progress()->average('seconds') ?? 0;
     }
 }


### PR DESCRIPTION
When there is no registered time in database average returns `null` but calculate() method has return type `int`